### PR TITLE
Fix bulk handling by separating events with newlines

### DIFF
--- a/classes/Loggly.cls
+++ b/classes/Loggly.cls
@@ -468,18 +468,8 @@ global with sharing class Loggly {
 		logList.addAll(logs);
 
 		HttpResponse res = new HttpResponse();
-		// Build up an array of JSON messages to send to the endpoint
-		String message = '[';
-
-		for (Integer i = 0; i < logList.size(); i++) {
-			message = message + logList.get(i);
-
-			if (i < logList.size() - 1) {
-				message = message + ',';
-			}
-		}
-
-		message = message + ']';
+		// Build up a newline-separated list of JSON messages to send to the endpoint
+		String message = String.join(logList, '\n');
 
 		try {
 			HttpRequest req = new HttpRequest();


### PR DESCRIPTION
For the bulk endpoint, Loggly expects JSON events to be separated by newlines rather than placed in a JSON array.

> Our HTTP/S bulk endpoint is great to send larger batches of line-separated events with faster transmission speed.
> https://www.loggly.com/docs/http-bulk-endpoint/

```
DateTime dt = DateTime.now();
Loggly l = new Loggly();
l.add('Test1', dt);
l.add('Test2', dt.addSeconds(1));
l.flush();
```

![loggly_bulk](https://cloud.githubusercontent.com/assets/1283264/12469656/a7f31f24-bfbb-11e5-92e4-b1c4aac21a51.png)